### PR TITLE
Support async functions that use tokio functionality

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["ffi", "bindgen"]
 [dependencies]
 # Re-exported dependencies used in generated Rust scaffolding files.
 anyhow = "1"
+async-compat = { version = "0.2.1", optional = true }
 bytes = "1.0"
 camino = "1.0.8"
 log = "0.4"
@@ -28,6 +29,9 @@ default = []
 # Use the `uniffi_bindgen` from this workspace instead of the one installed on your system.
 # You probably only want to enable this feature if you're working on uniffi itself.
 builtin-bindgen = ["uniffi_bindgen"]
+# Enable support for running async functions inside tokio's executor, instead of the foreign language's.
+# This must still be opted into on a per-function basis using `#[uniffi::export(async_runtime = "tokio")]`.
+tokio = ["dep:async-compat"]
 
 [dev-dependencies]
 trybuild = "1"

--- a/uniffi/src/ffi/rustfuture.rs
+++ b/uniffi/src/ffi/rustfuture.rs
@@ -323,7 +323,7 @@ where
         };
         let mut context = Context::from_waker(&waker);
 
-        Pin::new(&mut self.0).poll(&mut context).map(T::lower)
+        self.0.as_mut().poll(&mut context).map(T::lower)
     }
 }
 

--- a/uniffi/src/ffi/rustfuture.rs
+++ b/uniffi/src/ffi/rustfuture.rs
@@ -289,6 +289,14 @@ where
         Self(Box::pin(future))
     }
 
+    #[cfg(feature = "tokio")]
+    pub fn new_tokio<F>(future: F) -> Self
+    where
+        F: Future<Output = T> + 'static,
+    {
+        Self(Box::pin(async_compat::Compat::new(future)))
+    }
+
     /// Poll the future. It basically maps
     /// `<T as FfiConverter>::RustType` to `<T as FfiConverter>::FfiType` when
     /// the inner future is ready.

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -1,10 +1,6 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use syn::{
-    parse::{Parse, ParseStream},
-    punctuated::Punctuated,
-    Data, DeriveInput, Index, Token, Variant,
-};
+use syn::{parse::ParseStream, punctuated::Punctuated, Data, DeriveInput, Index, Token, Variant};
 use uniffi_meta::{ErrorMetadata, VariantMetadata};
 
 use crate::{
@@ -154,14 +150,12 @@ struct ErrorAttr {
     flat: Option<kw::flat_error>,
 }
 
-impl Parse for ErrorAttr {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+impl UniffiAttribute for ErrorAttr {
+    fn parse_one(input: ParseStream<'_>) -> syn::Result<Self> {
         let flat = input.parse()?;
         Ok(ErrorAttr { flat })
     }
-}
 
-impl UniffiAttribute for ErrorAttr {
     fn merge(self, other: Self) -> syn::Result<Self> {
         Ok(Self {
             flat: either_attribute_arg(self.flat, other.flat)?,

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -47,11 +47,12 @@ pub fn build_foreign_language_testcases(tokens: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn export(_attr: TokenStream, input: TokenStream) -> TokenStream {
+pub fn export(attr_args: TokenStream, input: TokenStream) -> TokenStream {
     let input2 = proc_macro2::TokenStream::from(input.clone());
 
     let gen_output = || {
         let mod_path = util::mod_path()?;
+        let args = syn::parse(attr_args)?;
         let mut item = syn::parse(input)?;
 
         // If the input is an `impl` block, rewrite any uses of the `Self` type
@@ -61,7 +62,7 @@ pub fn export(_attr: TokenStream, input: TokenStream) -> TokenStream {
         rewrite_self_type(&mut item);
 
         let metadata = export::gen_metadata(item, &mod_path)?;
-        Ok(expand_export(metadata, &mod_path))
+        Ok(expand_export(metadata, args, &mod_path))
     };
     let output = gen_output().unwrap_or_else(syn::Error::into_compile_error);
 


### PR DESCRIPTION
Adds `#[uniffi::export(async_runtime = "tokio")]` support.